### PR TITLE
Update GolangCI-lint to v1.53.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else
 endif
 
 # Variables
-GOLANGCI_VERSION=v1.53.2
+GOLANGCI_VERSION=v1.53.3
 
 vet:
 	go vet ${GO_PACKAGES}


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/1236

https://github.com/golangci/golangci-lint/releases/tag/v1.53.3