### PR TITLE
Update GolangCI-lint to v1.60.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,7 @@ linters:
     - dogsled
     - errcheck
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - funlen
     - goconst
     - gocritic
@@ -89,7 +89,7 @@ linters:
   # - nestif
   # - noctx
   # - prealloc
-  # - exportloopref
+  # - copyloopvar
   # - structcheck
   # - testpackage
   # - wsl

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else
 endif
 
 # Variables
-GOLANGCI_VERSION=v1.60.1
+GOLANGCI_VERSION=v1.60.3
 
 vet:
 	go vet ${GO_PACKAGES}

--- a/main.go
+++ b/main.go
@@ -243,6 +243,7 @@ func WaitDaemonsetReady(namespace, name string, timeout time.Duration) error {
 		return fmt.Errorf("failed to get node list, err:%s", err)
 	}
 
+	//nolint:gosec
 	nodesCount := int32(len(nodes.Items))
 	isReady := false
 	for start := time.Now(); !isReady && time.Since(start) < timeout; {


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2372