### PR TITLE
Update GolangCI-lint to v1.62.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,6 +115,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.60.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.62.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else
 endif
 
 # Variables
-GOLANGCI_VERSION=v1.60.3
+GOLANGCI_VERSION=v1.62.2
 
 vet:
 	go vet ${GO_PACKAGES}


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2598