### PR TITLE
Update Go to v1.24.0

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -16,24 +16,24 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Set up Go 1.23
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: 1.23.6
-
-      - name: Disable default go problem matcher
-        run: echo "::remove-matcher owner=go::"
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.sha }}
 
-      - name: Install golangci-lint
-        run: make install-lint
+      - name: Set up Go 1.24
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
 
-      - name: make lint
-        run: make lint
+      - name: Disable default go problem matcher
+        run: echo "::remove-matcher owner=go::"
+
+      - name: Golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64
+          args: --timeout 10m0s
 
       - name: make vet
         run: make vet

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,8 @@ else
   GOBIN=$(shell go env GOBIN)
 endif
 
-# Variables
-GOLANGCI_VERSION=v1.64.3
-
 vet:
 	go vet ${GO_PACKAGES}
-
-# Install golangci-lint	
-install-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GO_PATH}/bin ${GOLANGCI_VERSION}
 
 # Run configured linters
 lint:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-best-practices-for-k8s/privileged-daemonset
 
-go 1.23.6
+go 1.24.0
 
 require (
 	k8s.io/api v0.32.1


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2795

Also removes the manual steps for installing the golangci-linter and replaces with the Action.