### PR TITLE
Fix broken golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,11 +18,6 @@ linters-settings:
       - whyNoLint
   gocyclo:
     min-complexity: 15
-  mnd:
-    settings:
-      mnd:
-        # do not include the "operation" and "assign"
-        checks: argument,case,condition,return
   govet:
     settings:
       printf:
@@ -33,10 +28,7 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
   lll:
     line-length: 250
-  maligned:
-    suggest-new: true
   nolintlint:
-    allow-leading-space: false # disallow leading spaces. A space means the //nolint comment shows in `godoc` output.
     allow-unused: false # report any unused nolint directives
     require-explanation: false # do not require an explanation for nolint directives
     require-specific: true # require nolint directives to be specific about which linter is being skipped
@@ -110,11 +102,3 @@ issues:
         - gocritic
       text: "unnecessaryDefer:"
     # Ignore static strings in tests
-
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.64.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2819