### PR TITLE
Makefile improvements; golangci update/migrate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,9 @@
 version: "2"
 linters:
-  default: none
   enable:
     - bodyclose
     - copyloopvar
     - dogsled
-    - errcheck
     - exhaustive
     - funlen
     - goconst
@@ -13,8 +11,6 @@ linters:
     - gocyclo
     - goprintffuncname
     - gosec
-    - govet
-    - ineffassign
     - lll
     - misspell
     - mnd
@@ -22,45 +18,9 @@ linters:
     - nolintlint
     - revive
     - rowserrcheck
-    - staticcheck
     - unconvert
     - unparam
-    - unused
     - whitespace
-  settings:
-    dupl:
-      threshold: 100
-    funlen:
-      lines: 50
-      statements: 25
-    goconst:
-      min-len: 4
-      min-occurrences: 2
-    gocritic:
-      disabled-checks:
-        - whyNoLint
-      enabled-tags:
-        - diagnostic
-        - experimental
-        - opinionated
-        - performance
-        - style
-    gocyclo:
-      min-complexity: 15
-    govet:
-      settings:
-        printf:
-          funcs:
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-    lll:
-      line-length: 250
-    nolintlint:
-      require-explanation: false
-      require-specific: true
-      allow-unused: false
   exclusions:
     generated: lax
     presets:
@@ -68,25 +28,11 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    rules:
-      - linters:
-          - goconst
-          - mnd
-        path: _test\.go
-      - linters:
-          - lll
-        source: ^(.*= (".*"|`.*`))$
-      - linters:
-          - gocritic
-        text: 'unnecessaryDefer:'
     paths:
       - third_party$
       - builtin$
       - examples$
 formatters:
-  enable:
-    - gofmt
-    - goimports
   exclusions:
     generated: lax
     paths:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,36 @@
-GO_PACKAGES=$(shell go list ./... | grep -v vendor)
+# Variables
+GO ?= go
+GO_PACKAGES=$(shell $(GO) list ./... | grep -v vendor)
 
-.PHONY: install-lint \
-	lint \
-	vet
+# Default target
+.PHONY: all
+all: help
+
+# Help target
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  vet         Run go vet on all packages"
+	@echo "  lint        Run golangci-lint on all packages"
+	@echo "  test        Run go test on all packages"
+	@echo "  deps        Download go module dependencies"
+	@echo "  install-lint  Install golangci-lint if not present"
+	@echo "  clean       Remove build artifacts (if any)"
+
+# Dependency installation
+.PHONY: deps
+deps:
+	$(GO) mod tidy
+
+# Install golangci-lint if not present
+.PHONY: install-lint
+install-lint:
+	@if ! [ -x "$(GOBIN)/golangci-lint" ]; then \
+	  echo "Installing golangci-lint..."; \
+	  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v2.1.6; \
+	else \
+	  echo "golangci-lint already installed"; \
+	fi
 
 # Get default value of $GOBIN if not explicitly set
 GO_PATH=$(shell go env GOPATH)
@@ -18,3 +46,13 @@ vet:
 # Run configured linters
 lint:
 	golangci-lint run --timeout 10m0s
+
+# Test target
+.PHONY: test
+test:
+	$(GO) test -v ${GO_PACKAGES}
+
+# Clean target
+.PHONY: clean
+clean:
+	@echo "Nothing to clean (add commands if needed)"


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2875

### Linting Configuration Updates:
* Removed several linters and their configurations from `.golangci.yml`, simplifying the linting setup. Notable removals include `errcheck`, `govet`, `staticcheck`, and `unused`. Custom linter settings and rules were also removed.

### Makefile Enhancements:
* Added new targets to the `Makefile`, such as `help`, `deps`, `test`, and `clean`, to improve usability and provide clear documentation for available commands. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R33) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R49-R58)
* Introduced a check for installing `golangci-lint` if it is not already present, ensuring the linting tool is available for developers.

### Code Formatting and Readability:
* Refactored multiple functions in `main.go` to adhere to line-length limits (`lll`) and improve readability by breaking long lines into multiple lines. This includes changes in functions like `DeleteDaemonSet`, `IsDaemonSetReady`, `CreateDaemonSet`, and others. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L39-R39) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L153-R154) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L176-R187) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L203-R230) [[5]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L231-R241) [[6]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L250-R261) [[7]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L333-R358) [[8]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L374-R399) [[9]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L393-R411) [[10]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L411-R430)

These updates collectively aim to simplify the development process, ensure better code quality, and make the project more maintainable.