### PR TITLE
Update Go to 1.25.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-best-practices-for-k8s/privileged-daemonset
 
-go 1.25.1
+go 1.25.3
 
 require (
 	k8s.io/api v0.34.1


### PR DESCRIPTION
This PR updates the Go version to 1.25.4.

Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3310