### PR TITLE
chore: update Go to v1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-best-practices-for-k8s/privileged-daemonset
 
-go 1.26.0
+go 1.26.1
 
 require (
 	k8s.io/api v0.35.2


### PR DESCRIPTION
## Summary
- Update Go version from 1.26.0 to 1.26.1

## Jira
- [CNFCERT-1370](https://issues.redhat.com/browse/CNFCERT-1370)

## Related PRs
- [certsuite#3516](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3516)